### PR TITLE
feat(posts): change how the translation is done

### DIFF
--- a/content/blog/article-sans-traduction/index.md
+++ b/content/blog/article-sans-traduction/index.md
@@ -1,0 +1,9 @@
+---
+articleId: 3
+slug: /article-sans-traduction/
+title: Article sans traduction
+date: '2021-01-17'
+spoiler: Article sans traduction
+---
+
+Article sans traduction anglaise.

--- a/content/blog/deuxieme-article/index en.md
+++ b/content/blog/deuxieme-article/index en.md
@@ -1,0 +1,9 @@
+---
+articleId: 2
+slug: /second-article/
+title: Second article
+date: '2021-01-10'
+spoiler: Second article
+---
+
+Second article in translation process.

--- a/content/blog/deuxieme-article/index.md
+++ b/content/blog/deuxieme-article/index.md
@@ -1,5 +1,6 @@
 ---
 articleId: 2
+slug: /deuxieme-article/
 title: Deuxième article
 date: '2021-01-10'
 spoiler: Deuxième article

--- a/content/blog/voyage-commence/index.en.md
+++ b/content/blog/voyage-commence/index.en.md
@@ -1,5 +1,6 @@
 ---
 articleId: 1
+slug: /journey-begins/
 title: The Journey Begins
 date: '2019-01-26'
 spoiler: It's now or never

--- a/content/blog/voyage-commence/index.md
+++ b/content/blog/voyage-commence/index.md
@@ -1,5 +1,6 @@
 ---
 articleId: 1
+slug: /voyage-commence/
 title: Le voyage commence
 date: '2019-01-26'
 spoiler: C'est maintenant ou jamais

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link, graphql } from 'gatsby';
+import { graphql } from 'gatsby';
+import { LocalizedLink } from 'gatsby-theme-i18n';
 
 import Bio from '../components/Bio';
 import Layout from '../components/Layout';
@@ -16,7 +17,7 @@ const BlogIndex = ({ data, location, pageContext: { locale: language } }) => {
   const siteTitle = translate('site-title');
   const seoTitle = translate('homepage-title-seo');
   const posts = data.allMarkdownRemark.nodes.filter(
-    (post) => post.fields.keyLanguage === language
+    (post) => post.fields.language === language
   );
 
   if (posts.length === 0) {
@@ -56,9 +57,13 @@ const BlogIndex = ({ data, location, pageContext: { locale: language } }) => {
               >
                 <header>
                   <h2>
-                    <Link to={post.fields.slug} itemProp="url">
+                    <LocalizedLink
+                      itemProp="url"
+                      to={post.frontmatter.slug}
+                      language={language}
+                    >
                       <span itemProp="headline">{title}</span>
-                    </Link>
+                    </LocalizedLink>
                   </h2>
                   <p>
                     {formatPostDate(post.frontmatter.date, language)}
@@ -97,11 +102,11 @@ export const pageQuery = graphql`
       nodes {
         excerpt
         fields {
-          slug
-          keyLanguage
+          language
         }
         timeToRead
         frontmatter {
+          slug
           date(formatString: "MMMM DD, YYYY")
           title
           spoiler

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link, graphql } from 'gatsby';
+import { graphql } from 'gatsby';
 import { LocalizedLink } from 'gatsby-theme-i18n';
 
 import Bio from '../components/Bio';
@@ -22,7 +22,7 @@ const BlogPostTemplate = ({
   const { previous, next } = data;
 
   const translatedPost = translatedPosts.find(
-    (post) => post.keyLanguage !== language
+    (post) => post.language !== language
   );
   const languageMenu = translatedPost ? (
     <LanguageMenu to={translatedPost.slug} language={language} />
@@ -77,16 +77,24 @@ const BlogPostTemplate = ({
         >
           <li>
             {previous && (
-              <Link to={previous.fields.slug} rel="prev">
+              <LocalizedLink
+                to={previous.frontmatter.slug}
+                language={language}
+                rel="prev"
+              >
                 ← {previous.frontmatter.title}
-              </Link>
+              </LocalizedLink>
             )}
           </li>
           <li>
             {next && (
-              <Link to={next.fields.slug} rel="next">
+              <LocalizedLink
+                to={next.frontmatter.slug}
+                language={language}
+                rel="next"
+              >
                 {next.frontmatter.title} →
-              </Link>
+              </LocalizedLink>
             )}
           </li>
         </ul>
@@ -113,7 +121,7 @@ export const pageQuery = graphql`
       id
       excerpt(pruneLength: 160)
       fields {
-        keyLanguage
+        language
       }
       html
       frontmatter {
@@ -124,18 +132,14 @@ export const pageQuery = graphql`
       timeToRead
     }
     previous: markdownRemark(id: { eq: $previousPostId }) {
-      fields {
-        slug
-      }
       frontmatter {
+        slug
         title
       }
     }
     next: markdownRemark(id: { eq: $nextPostId }) {
-      fields {
-        slug
-      }
       frontmatter {
+        slug
         title
       }
     }


### PR DESCRIPTION
Change how we translate posts. Blog contents have a convention that an `articleId `and a `slug` are mandatory.
We keep creating the node field slug with a path including languages for `gatsby-plugin-feed` RSS.